### PR TITLE
Remove backticks from code to enable embedding

### DIFF
--- a/dracula.css
+++ b/dracula.css
@@ -523,7 +523,7 @@ code {
 }
 
 
-/* Multiline code blocks with ``` */
+/* Multiline code blocks with triple backtick */
 
 .rm-code-block {
   background-color: var(--background);


### PR DESCRIPTION
The triple backticks in a comment tell Roam to end the CSS code block when embedding the theme directly in Roam.

Removing those ``` allows the theme to be embedded directly on Roam. This, in turn, removes the browser extension dependency and enables its use in the Roam desktop app.

